### PR TITLE
chore: bump device_info_plus to 12.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   http: ^1.5.0
   path_provider: ^2.1.5
   archive: ^4.0.7
-  device_info_plus: ^11.5.0
+  device_info_plus: ^12.1.0
   shared_preferences: ^2.5.3
   package_info_plus: ^8.3.1
   uuid: ^4.5.1


### PR DESCRIPTION
Updates device_info_plus dependency to ^12.1.0.