### PR TITLE
Honor isTelemetryEnabled in model-catalog fetches (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ import 'package:cactus/cactus.dart';
 CactusConfig.isTelemetryEnabled = false;
 ```
 
+When `isTelemetryEnabled = false`, the SDK suppresses all outbound traffic to Cactus infrastructure: log records, device registration, and model-catalog lookups (`getModel`, `getModels`, `getVoiceModels`). This means **new model downloads will fail unless the model metadata is already in the local cache** (populated on any prior successful `getModel` call). For privacy- or offline-first apps, pre-warm the cache on first launch before disabling telemetry, or ship with the model bundled in your app assets.
+
 You can also optionally set a telemetry token to track usage across your organization:
 
 ```dart

--- a/lib/services/lm.dart
+++ b/lib/services/lm.dart
@@ -57,7 +57,7 @@ class CactusLM {
   }
 
   Future<void> initializeModel({final CactusInitParams? params}) async {
-    if (!Telemetry.isInitialized) {
+    if (CactusConfig.isTelemetryEnabled && !Telemetry.isInitialized) {
       await Telemetry.init(CactusConfig.telemetryToken);
     }
 

--- a/lib/services/stt.dart
+++ b/lib/services/stt.dart
@@ -47,7 +47,7 @@ class CactusSTT {
   }
 
   Future<void> initializeModel({final CactusInitParams? params}) async {
-    if (!Telemetry.isInitialized) {
+    if (CactusConfig.isTelemetryEnabled && !Telemetry.isInitialized) {
       await Telemetry.init(CactusConfig.telemetryToken);
     }
 

--- a/lib/src/services/api/supabase.dart
+++ b/lib/src/services/api/supabase.dart
@@ -133,6 +133,10 @@ class Supabase {
   }
 
   static Future<CactusModel?> getModel(String slug) async {
+    if (!CactusConfig.isTelemetryEnabled) {
+      return ModelCache.loadModel(slug);
+    }
+
     try {
       final client = HttpClient();
       final uri = Uri.parse('$_supabaseUrl/functions/v1/get-models?slug=$slug&sdk_name=flutter&sdk_version=$packageVersion');
@@ -158,6 +162,10 @@ class Supabase {
   }
 
   static Future<List<CactusModel>> fetchModels() async {
+    if (!CactusConfig.isTelemetryEnabled) {
+      return const <CactusModel>[];
+    }
+
     try {
       final client = HttpClient();
       final uri = Uri.parse('$_supabaseUrl/functions/v1/get-models?sdk_name=flutter&sdk_version=$packageVersion');
@@ -186,6 +194,10 @@ class Supabase {
   }
 
   static Future<List<VoiceModel>> fetchVoiceModels({String? provider}) async {
+    if (!CactusConfig.isTelemetryEnabled) {
+      return const <VoiceModel>[];
+    }
+
     final client = HttpClient();
 
     try {

--- a/lib/src/services/api/supabase.dart
+++ b/lib/src/services/api/supabase.dart
@@ -132,6 +132,9 @@ class Supabase {
     }
   }
 
+  /// Fetch model metadata by slug. When [CactusConfig.isTelemetryEnabled]
+  /// is false, returns the locally cached entry (or null if none exists)
+  /// without making any network call.
   static Future<CactusModel?> getModel(String slug) async {
     if (!CactusConfig.isTelemetryEnabled) {
       return ModelCache.loadModel(slug);
@@ -161,6 +164,8 @@ class Supabase {
     }
   }
 
+  /// Fetch the full model catalog. When [CactusConfig.isTelemetryEnabled]
+  /// is false, returns an empty list without making any network call.
   static Future<List<CactusModel>> fetchModels() async {
     if (!CactusConfig.isTelemetryEnabled) {
       return const <CactusModel>[];
@@ -193,6 +198,10 @@ class Supabase {
     }
   }
 
+  /// Fetch the voice model catalog. When [CactusConfig.isTelemetryEnabled]
+  /// is false, returns an empty list without making any network call —
+  /// callers that need offline voice-model resolution must maintain their
+  /// own cache or ship voice models as bundled assets.
   static Future<List<VoiceModel>> fetchVoiceModels({String? provider}) async {
     if (!CactusConfig.isTelemetryEnabled) {
       return const <VoiceModel>[];

--- a/test/services/api/supabase_test.dart
+++ b/test/services/api/supabase_test.dart
@@ -1,0 +1,113 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:cactus/cactus.dart';
+import 'package:cactus/src/services/api/supabase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _ThrowingHttpOverrides extends HttpOverrides {
+  int attempts = 0;
+
+  @override
+  HttpClient createHttpClient(SecurityContext? context) {
+    attempts += 1;
+    throw const SocketException(
+      'Test override: network access is forbidden when telemetry is disabled',
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _ThrowingHttpOverrides overrides;
+  late bool originalTelemetryEnabled;
+
+  setUp(() {
+    originalTelemetryEnabled = CactusConfig.isTelemetryEnabled;
+    overrides = _ThrowingHttpOverrides();
+    HttpOverrides.global = overrides;
+  });
+
+  tearDown(() async {
+    HttpOverrides.global = null;
+    CactusConfig.isTelemetryEnabled = originalTelemetryEnabled;
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  group('Supabase honors isTelemetryEnabled = false', () {
+    test('getModel returns cached model without constructing HttpClient', () async {
+      CactusConfig.isTelemetryEnabled = false;
+      final cached = jsonEncode(<String, dynamic>{
+        'created_at': '2025-01-01T00:00:00.000Z',
+        'slug': 'qwen3-0.6',
+        'download_url': 'https://example.com/qwen3-0.6.gguf',
+        'size_mb': 600,
+        'supports_tool_calling': true,
+        'supports_vision': false,
+        'name': 'Qwen 3 0.6B',
+        'is_downloaded': false,
+      });
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'cactus_model_qwen3-0.6': cached,
+      });
+
+      final model = await Supabase.getModel('qwen3-0.6');
+
+      expect(model, isNotNull);
+      expect(model!.slug, 'qwen3-0.6');
+      expect(model.name, 'Qwen 3 0.6B');
+      expect(
+        overrides.attempts,
+        0,
+        reason: 'getModel must not construct HttpClient when telemetry is off',
+      );
+    });
+
+    test('getModel returns null on cache miss without constructing HttpClient', () async {
+      CactusConfig.isTelemetryEnabled = false;
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+
+      final model = await Supabase.getModel('unknown-slug');
+
+      expect(model, isNull);
+      expect(overrides.attempts, 0);
+    });
+
+    test('fetchModels returns const empty list without constructing HttpClient', () async {
+      CactusConfig.isTelemetryEnabled = false;
+
+      final models = await Supabase.fetchModels();
+
+      expect(models, isEmpty);
+      expect(
+        overrides.attempts,
+        0,
+        reason: 'fetchModels must not construct HttpClient when telemetry is off',
+      );
+    });
+
+    test('fetchVoiceModels returns const empty list without constructing HttpClient', () async {
+      CactusConfig.isTelemetryEnabled = false;
+
+      final voiceModels = await Supabase.fetchVoiceModels();
+
+      expect(voiceModels, isEmpty);
+      expect(
+        overrides.attempts,
+        0,
+        reason: 'fetchVoiceModels must not construct HttpClient when telemetry is off',
+      );
+    });
+
+    test('fetchVoiceModels guard fires before provider-specific branching', () async {
+      CactusConfig.isTelemetryEnabled = false;
+
+      final voiceModels = await Supabase.fetchVoiceModels(provider: 'whisper');
+
+      expect(voiceModels, isEmpty);
+      expect(overrides.attempts, 0);
+    });
+  });
+}


### PR DESCRIPTION
Closes #33.

## Summary

`CactusConfig.isTelemetryEnabled = false` is documented as the kill switch for outbound traffic, but three Supabase methods (`getModel`, `fetchModels`, `fetchVoiceModels`) ignored it and phoned home on every boot. This PR adds the same early-return guard those methods already use in `sendLogRecord` / `registerDevice`, closes a parallel leak in `Telemetry.init`, and documents the full scope of the flag so developers opting out know what to expect.

## Changes

**Core fix** (`lib/src/services/api/supabase.dart`):
- `getModel(slug)` short-circuits to `ModelCache.loadModel(slug)` when telemetry is off (matches the existing failure-path fallback).
- `fetchModels()` returns `const <CactusModel>[]`.
- `fetchVoiceModels()` returns `const <VoiceModel>[]`.
- Dartdoc comments added to each method documenting the telemetry-off behavior on the public-ish API surface.

**Adjacent leak closure** (`lib/services/lm.dart`, `lib/services/stt.dart`):
- `Telemetry.init` is no longer called from `CactusLM.initializeModel` / `CactusSTT.initializeModel` when telemetry is disabled. Previously the call ran unconditionally and relied on `registerDevice`'s internal guard to no-op — a defense-in-depth pattern that would have silently leaked if any code were added to `Telemetry.init` before the Supabase chokepoint.

**Documentation** (`README.md`):
- The Configuration section now states that disabling telemetry suppresses log records, device registration, **and** model-catalog lookups, and that new downloads will fail unless models are pre-cached or bundled. Privacy-first apps should pre-warm `ModelCache` on first launch or ship models as assets.

**Tests** (`test/services/api/supabase_test.dart`, first test file in the repo):
- Installs `HttpOverrides.global` that throws on any socket open with an attempt counter.
- Asserts each guarded method returns its documented fallback and the counter stays at `0` — i.e., not just "no HTTP request completed" but "no `HttpClient` was even constructed."
- Five cases: `getModel` cache hit, `getModel` cache miss, `fetchModels`, `fetchVoiceModels`, and `fetchVoiceModels(provider: 'whisper')` (pinning that the guard fires before provider branching).

## Test plan

- [x] `flutter test test/services/api/supabase_test.dart` — all 5 tests pass
- [x] `flutter analyze` clean on all touched files
- [ ] Reviewer: confirm `Telemetry.init` skip doesn't break callers that read `Telemetry.isInitialized` afterwards (current call sites check `isInitialized` before dispatching, so no behavior change for the telemetry-disabled path)
- [ ] Reviewer: confirm README guidance matches the team's intended product framing for the opt-out

## Out of scope

Identified during code review but not addressed here — flag separately if you want them tracked:
- Hardcoded Supabase anon JWT in source (pre-existing)
- `fetchVoiceModels` is the only method without an outer `catch` (pre-existing)
- `HttpClient()` has no `connectionTimeout` anywhere (pre-existing)
- `ModelCache` doesn't persist the `quantization` field (pre-existing)
- The 5×-duplicated `isTelemetryEnabled` guard could become a helper — left as a deliberate design call rather than auto-applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)